### PR TITLE
added demo of spiderweb chart to vignette

### DIFF
--- a/vignettes/replicating-highcharts-demos.Rmd
+++ b/vignettes/replicating-highcharts-demos.Rmd
@@ -8,7 +8,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-Let's repliate the [line-lables](http://www.highcharts.com/demo/line-labels) demo. If you click
+Let's replicate the [line-lables](http://www.highcharts.com/demo/line-labels) demo. If you click
 *View Options* button you'll see the code to create that chart in a html file via javascript. Let's
 take a look to the options which are:
 
@@ -174,7 +174,82 @@ hc
 
 ```
 
-If you dont get what you hope to get you must check if you passed all the arguments correctly.
+A third and slightly more complicated example is the [spiderweb](http://www.highcharts.com/demo/polar-spider) chart. 
+
+```
+{
+  chart: {
+    polar: true,
+    type: 'line'
+  },
+  title: {
+    text: 'Budget vs spending',
+    x: -80
+  },
+  pane: {
+    size: '80%'
+  },
+  xAxis: {
+    categories: ['Sales', 'Marketing', 'Development', 'Customer Support', 'Information Technology', 'Administration'],
+    tickmarkPlacement: 'on',
+    lineWidth: 0
+  },
+  yAxis: {
+    gridLineInterpolation: 'polygon',
+    lineWidth: 0,
+    min: 0
+  },
+  tooltip: {
+    shared: true,
+    pointFormat: '<span style="color:{series.color}">{series.name}: <b>${point.y:,.0f}</b><br/>'
+  },
+  legend: {
+    align: 'right',
+    verticalAlign: 'top',
+    y: 70,
+    layout: 'vertical'
+  },
+  series: [{
+    name: 'Allocated Budget',
+    data: [43000, 19000, 60000, 35000, 17000, 10000],
+    pointPlacement: 'on'
+  }, {
+    name: 'Actual Spending',
+    data: [50000, 39000, 42000, 31000, 26000, 14000],
+    pointPlacement: 'on'
+  }]
+}
+```
+
+Here's the code for the `highchart` object:
+
+```{r}
+highchart() %>% 
+  hc_chart(polar = TRUE, type = "line") %>% 
+  hc_title(text = "Budget vs Spending") %>% 
+  hc_xAxis(categories = c('Sales', 'Marketing', 'Development', 'Customer Support', 
+                          'Information Technology', 'Administration'),
+           tickmarkPlacement = 'on',
+           lineWidth = 0) %>% 
+  hc_yAxis(gridLineInterpolation = 'polygon',
+           lineWidth = 0,
+           min = 0) %>% 
+  hc_series(
+    list(
+      name = "Allocated Budget",
+      data = c(43000, 19000, 60000, 35000, 17000, 10000),
+      pointPlacement = 'on'
+    ),
+    list(
+      name = "Actual Spending",
+      data = c(50000, 39000, 42000, 31000, 26000, 14000),
+     pointPlacement = 'on'
+    )
+  )
+```
+
+
+If you don't get what you hope to get you must check if you passed all the arguments correctly.
 You can compare the javascript object with:
 
 ```{r}


### PR DESCRIPTION
Minor change here - I couldn't find any examples of how to make a [spiderweb chart](http://www.highcharts.com/demo/polar-spider) so I extended your vignette to do this. Looks like you have documentation in gh-pages - would be nice to have this example there. Might be able to do this if you want/need the help.

Great package! Thanks for the awesome work. 