### PR TITLE
Add data point attributes to be used in tooltips

### DIFF
--- a/R/shortcuts.R
+++ b/R/shortcuts.R
@@ -144,13 +144,13 @@ hc_add_series_scatter <- function(hc, x, y, z = NULL, color = NULL, label = NULL
   for (i in seq_along(args)) {
     if (length(x) == length(args[[i]])) {
       attr <- list(args[i])
-      name <- names(args)[i]
-      df <- cbind(df, setNames(attr, name))
+      names(attr) <- names(args)[i]
+      df <- cbind(df, attr)
       # Used argument is set to zero length
       args[[i]] <- character(0)
     }
   }
-  # Pass the remaining arguments to the function
+  # Remove already used arguments
   args <- Filter(length, args)
   
   ds <- list.parse3(df)

--- a/R/shortcuts.R
+++ b/R/shortcuts.R
@@ -102,11 +102,16 @@ hc_add_series_df <- function(hc, data, ...) {
 #' hc_add_series_scatter(hc, mtcars$wt, mtcars$mpg, mtcars$drat, mtcars$qsec)
 #' hc_add_series_scatter(hc, mtcars$wt, mtcars$mpg, mtcars$drat, mtcars$qsec, rownames(mtcars))
 #' 
+#' # Add named attributes to data (attributes length needs to match number of rows)
+#' hc_add_series_scatter(hc, mtcars$wt, mtcars$mpg, mtcars$drat, mtcars$qsec,
+#'                       name = rownames(mtcars), gear = mtcars$gear) %>%
+#'   hc_tooltip(pointFormat = "<b>{point.name}</b><br/>Gear: {point.gear}")
+#' 
 #' @importFrom dplyr mutate group_by do select data_frame
 #' 
 #' @export 
 hc_add_series_scatter <- function(hc, x, y, z = NULL, color = NULL, label = NULL,
-                                 showInLegend = FALSE, viridis.option = "D", ...) {
+                                  showInLegend = FALSE, viridis.option = "D", ...) {
   
   assertthat::assert_that(.is_highchart(hc), length(x) == length(y),
                           is.numeric(x), is.numeric(y))
@@ -134,6 +139,20 @@ hc_add_series_scatter <- function(hc, x, y, z = NULL, color = NULL, label = NULL
     df <- df %>% mutate(label = label)
   }
   
+  # Add arguments to data points if they match the length of the data
+  args <- list(...)
+  for (i in seq_along(args)) {
+    if (length(x) == length(args[[i]])) {
+      attr <- list(args[i])
+      name <- names(args)[i]
+      df <- cbind(df, setNames(attr, name))
+      # Used argument is set to zero length
+      args[[i]] <- character(0)
+    }
+  }
+  # Pass the remaining arguments to the function
+  args <- Filter(length, args)
+  
   ds <- list.parse3(df)
   
   type <- ifelse(!is.null(z), "bubble", "scatter")
@@ -144,11 +163,12 @@ hc_add_series_scatter <- function(hc, x, y, z = NULL, color = NULL, label = NULL
     dlopts <- list(enabled = FALSE)
   }
   
-  hc %>% hc_add_series(data = ds,
-                       type = type,
-                       showInLegend = showInLegend,
-                       dataLabels = dlopts, ...)
-  
+  do.call("hc_add_series", c(list(hc,
+                                  data = ds, 
+                                  type = type, 
+                                  showInLegend = showInLegend, 
+                                  dataLabels = dlopts),
+                             args))
 }
 
 #' @rdname hc_add_series_scatter

--- a/demo/scatter-ex.R
+++ b/demo/scatter-ex.R
@@ -9,3 +9,16 @@ highchart() %>%
   hc_yAxis(title = list(text = "Miles/gallon")) %>% 
   hc_tooltip(headerFormat = "<b>{series.name} cylinders</b><br>",
              pointFormat = "{point.x} (lb/1000), {point.y} (miles/gallon)")
+
+highchart() %>% 
+  hc_add_series_scatter(mtcars$wt, mtcars$mpg, car = rownames(mtcars), 
+                        hp = mtcars$hp, gear = mtcars$gear) %>% 
+  hc_chart(zoomType = "xy") %>% 
+  hc_title(text = "Motor Trend Car Road Tests") %>% 
+  hc_xAxis(title = list(text = "Weight"), minorTickInterval = "auto") %>% 
+  hc_yAxis(title = list(text = "Miles/gallon")) %>% 
+  hc_tooltip(pointFormat = "<b>{point.car}</b><br/>
+                            Weight: {point.x} lb/1000<br/>
+                            MPG: {point.y}<br/>
+                            Horsepower: {point.hp}<br/>
+                            Forward gears: {point.gear}")

--- a/man/hc_add_series_scatter.Rd
+++ b/man/hc_add_series_scatter.Rd
@@ -47,5 +47,10 @@ hc_add_series_scatter(hc, mtcars$wt, mtcars$mpg, mtcars$drat, mtcars$am)
 hc_add_series_scatter(hc, mtcars$wt, mtcars$mpg, mtcars$drat, mtcars$qsec)
 hc_add_series_scatter(hc, mtcars$wt, mtcars$mpg, mtcars$drat, mtcars$qsec, rownames(mtcars))
 
+# Add named attributes to data points (attributes length needs to match number of rows)
+hc_add_series_scatter(hc, mtcars$wt, mtcars$mpg, mtcars$drat, mtcars$qsec,
+                      name = rownames(mtcars), gear = mtcars$gear) \%>\%
+  hc_tooltip(pointFormat = "<b>{point.name}</b><br/>Gear: {point.gear}")
+
 }
 


### PR DESCRIPTION
When the named attributes passed onto the function `hc_add_series_scatter` have a length equal to the number of rows of the data, the attributes should be placed in the respective point (just like you do with the `label` argument). Passing these extra data attributes allows to use them in the tooltip as you can see in the image below.

The example depicted in the right plot is obtained with the code highlighted in the left. Note that the tooltip displays car names, horsepower data and number of gears.
 
![screen shot 2016-04-19 at 17 40 10](https://cloud.githubusercontent.com/assets/3199157/14648076/6c043f00-0658-11e6-85bb-496c881e98f5.png)