### PR TITLE
Fix bug when naming scatter series with only one point

### DIFF
--- a/R/shortcuts.R
+++ b/R/shortcuts.R
@@ -153,7 +153,7 @@ hc_add_series_scatter <- function(hc, x, y, z = NULL, color = NULL, label = NULL
   # Add arguments to data points if they match the length of the data
   args <- list(...)
   for (i in seq_along(args)) {
-    if (length(x) == length(args[[i]])) {
+    if (length(x) == length(args[[i]]) && names(args[i]) != "name") {
       attr <- list(args[i])
       names(attr) <- names(args)[i]
       df <- cbind(df, attr)


### PR DESCRIPTION
Hey there, @jbkunst!

`hc_add_series_scatter` allows to pass attributes to the individual data points if the argument passed to `…` have the same length as the data points. This raises a problem: if we only give ONE data point, all the arguments passed to `…` will be used as attributes to that data point. This means, for example, that when trying to give a name to the series, it'll give a name to the data point instead (and the series will be named "Series 1" instead of the name we want).

A simple fix to avoid this is to check if the attribute passed in `…` is named "name", it will not be used as a data point attribute (see code changed). This may still be problematic if there are other attributes of interest that shouldn't be made as a data point attribute.

An alternative solution would be to see if there is only one data point and in that case, don't use anything as a data point attribute… However, we may have a reason to use this feature with only one data point.

I'm not really sure how to fix this issue… Any ideas?