### PR TITLE
Add missing braces

### DIFF
--- a/R/api-hc-hc_add_series.R
+++ b/R/api-hc-hc_add_series.R
@@ -426,10 +426,11 @@ mutate_mapping <- function(data, mapping, drop = FALSE) {
     #new <- "series"
     data <- dplyr::rename(data, "seriess" = "series")
   
-  if(drop)
+  if(drop) {
     newv <- rlang::syms(newv)
     data <- dplyr::select(data, !!! newv)
-  
+  }
+
   data
   
 }


### PR DESCRIPTION
All unmapped variables get dropped otherwise.