### PR TITLE
Add parameter quiet to download_map_data function 

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Authors@R: c(
   person("Adline", "Dsilva", role = c("ctb"), comment  = "First version Matrix heatmap"),
   person("Kamil", "Slowikowski", role = c("ctb"), comment = c(ORCID = "0000-0002-2843-6370")),
   person("Christian", "Minich", role = c("ctb"), comment  = "hcaes mutate_mapping improvement"),
-  person("Jonathan", "Armond", role = c("ctb"), comment = "mutate_mapping bugfix")
+  person("Jonathan", "Armond", role = c("ctb"), comment = "mutate_mapping bugfix"),
+  person("David", "Breuer", role = c("ctb"), comment = "download_map_data quiet parameter")
   )
 URL: http://jkunst.com/highcharter
 BugReports: https://github.com/jbkunst/highcharter/issues

--- a/R/highmaps.R
+++ b/R/highmaps.R
@@ -160,6 +160,7 @@ hcmap <- function(map = "custom/world",
 #' @param url The map's url.
 #' @param showinfo Show the properties of the downloaded map to know how
 #'   are the keys to add data in \code{hcmap}.
+#' @param quiet Boolean parameter to turn off download messages (on by default).
 #' @examples
 #' \dontrun{
 #' mpdta <- download_map_data("https://code.highcharts.com/mapdata/countries/us/us-ca-all.js")
@@ -169,13 +170,14 @@ hcmap <- function(map = "custom/world",
 #' @importFrom dplyr glimpse
 #' @importFrom utils download.file
 #' @export
-download_map_data <- function(url = "custom/world.js", showinfo = FALSE) {
+download_map_data <- function(url = "custom/world.js", showinfo = FALSE, 
+                              quiet = FALSE) {
   
   url <- sprintf("https://code.highcharts.com/mapdata/%s",
                  fix_map_name(url))
   
   tmpfile <- tempfile(fileext = ".js")
-  download.file(url, tmpfile)
+  download.file(url, tmpfile, quiet = quiet)
   mapdata <- readLines(tmpfile, warn = FALSE, encoding = "UTF-8")
   mapdata[1] <- gsub(".* = ", "", mapdata[1])
   mapdata <- paste(mapdata, collapse = "\n")

--- a/man/download_map_data.Rd
+++ b/man/download_map_data.Rd
@@ -4,13 +4,16 @@
 \alias{download_map_data}
 \title{Helper function to download the map data form a url}
 \usage{
-download_map_data(url = "custom/world.js", showinfo = FALSE)
+download_map_data(url = "custom/world.js", showinfo = FALSE,
+  quiet = FALSE)
 }
 \arguments{
 \item{url}{The map's url.}
 
 \item{showinfo}{Show the properties of the downloaded map to know how
 are the keys to add data in \code{hcmap}.}
+
+\item{quiet}{Boolean parameter to turn off download messages (on by default).}
 }
 \description{
 The urls are listed in \url{https://code.highcharts.com/mapdata/}.


### PR DESCRIPTION
- Add parameter quiet to download_map_data function to suppress download messages.
- This is useful and convenient for (unit) testing to avoid unneeded messages.
- Default is quiet = FALSE to ensure original/expected behavior. 
- The parameter is simply passed on to the internally used download.file function.
- Docs were updated accordingly.
