### PR TITLE
Fix warnings for numeric vectors with multiple classes

### DIFF
--- a/R/helpers.R
+++ b/R/helpers.R
@@ -353,7 +353,7 @@ fix_1_length_data <- function(x) {
     message("fix_1_length")
   }
 
-  if (class(x) != "list" & length(x) == 1) {
+  if (!is.list(x) && length(x) == 1) {
     x <- list(x)
   }
   x


### PR DESCRIPTION
Hey @jbkunst, hope everything is going great! :)

When you try to use `hc_add_series()` using a numeric vector that has more than one class, a warning is raised:

```R
library(highcharter)
vec <- 2
class(vec)
# [1] "numeric"
highchart() %>% hc_add_series(vec)

class(vec) <- c("special", class(vec))
class(vec)
# [1] "special" "numeric"
highchart() %>% hc_add_series(vec)
# Warning message:
# In if (class(x) != "list" & length(x) == 1) x <- list(x) :
#  the condition has length > 1 and only the first element will be used
```

This is because the code is checking if every class of an object is a list instead of simply checking if the object itself is a list (see my proposed change to the code).

Cheers,
Nuno