### PR TITLE
check for chart type

### DIFF
--- a/R/hchart.R
+++ b/R/hchart.R
@@ -10,8 +10,6 @@
 #' @param ... Additional arguments for the data series
 #'    (\url{http://api.highcharts.com/highcharts#series}).
 #'
-#' @importFrom assertthat assert_that
-#' @importFrom assertthat is.string
 #'
 #' @export
 hchart <- function(object, ...) {
@@ -42,7 +40,8 @@ hchart.data.frame <- function(object, type = NULL, mapping = hcaes(), ...) {
   if (getOption("highcharter.verbose")) {
     message("hchart.data.frame")
   }
-  assert_that(is.string(type), msg = "Chart type must be provided.")
+  assertthat::assert_that(assertthat::is.string(type), 
+                          msg = "Chart type must be provided.")
   
   object <- as.data.frame(object)
   

--- a/R/hchart.R
+++ b/R/hchart.R
@@ -10,6 +10,9 @@
 #' @param ... Additional arguments for the data series
 #'    (\url{http://api.highcharts.com/highcharts#series}).
 #'
+#' @importFrom assertthat assert_that
+#' @importFrom assertthat is.string
+#'
 #' @export
 hchart <- function(object, ...) {
   UseMethod("hchart")
@@ -39,9 +42,10 @@ hchart.data.frame <- function(object, type = NULL, mapping = hcaes(), ...) {
   if (getOption("highcharter.verbose")) {
     message("hchart.data.frame")
   }
-
+  assert_that(is.string(type), msg = "Chart type must be provided.")
+  
   object <- as.data.frame(object)
-
+  
   data <- mutate_mapping(object, mapping)
 
   series <- data_to_series(data, mapping, type = type, ...)

--- a/tests/testthat/test-hchart.R
+++ b/tests/testthat/test-hchart.R
@@ -128,3 +128,8 @@ test_that("hchart fails after mispelled chart type", {
   # sactter = scatter mispelled
   expect_error(hchart(mgp, "sactter", hcaes(x = displ, y = hwy, group = class)))
 })
+
+test_that("hchart fails when chart type is not given", {
+  expect_error(hchart(mpg, hcaes(x = displ, y = hwy, group = class)),
+               "type")
+})


### PR DESCRIPTION
When a user forgets to add a `type` to `hchart`, a non-informative error is thrown:

```{r}
library(highcharter)
hchart(mtcars, hcaes(x = mpg, y = cyl))
#> Error: Assigned data `type` must be compatible with existing data.
#> x Existing data has 1 row.
#> x Assigned data has 2 rows.
#> i Row updates require a list value. Do you need `list()` or `as.list()`?
#> Warning in if (type == "heatmap") {: Condition has length > 1 and only the first element will be used.
#> 2: In if (type %in% c("bubble", "scatter")) { : Condition has length > 1 and only the first element will be used.
```

This PR enables the following behaviour:

```{r}
library(highcharter)
hchart(mtcars, hcaes(x = mpg, y = cyl))
#> Error: Chart type must be provided.
```