### PR TITLE
Display all censor points in survival plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@ when the size of viewport is small (like tables o phones).
 
 * Removing `knitr.figure = FALSE` option in `sizingPolicy = htmlwidgets::sizingPolicy`
 to fix #703 
+* Update hchart.survfit function to display censor points when multiple individuals
+  are censored at the same time point. This fixes #742.
 
 ## Internal
 

--- a/R/hchart.R
+++ b/R/hchart.R
@@ -635,7 +635,7 @@ hchart.survfit <- function(object, ..., fun = NULL, markTimes = TRUE,
   marker <- list(list(fillColor = markerColor, symbol = symbol, enabled = TRUE))
 
   if (markTimes) {
-    mark <- object$n.censor == 1
+    mark <- object$n.censor >= 1
   } else {
     mark <- FALSE
   }


### PR DESCRIPTION
Fixes #742

This change ensures that censor points are displayed on survival plots when more than one individual is censored at the same time point.