### PR TITLE
Fix CRAN checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Changes
 
 * Highcharter now uses HighchartsJS 10.2.0.
+* Fix `download_map_data` to prevent 403 Forbidden errors when fetching data.
 
 # highcharter 0.9.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 
 * Highcharter now uses HighchartsJS 10.2.0.
 
+## Bugs
+
+* Wrapped examples making network calls in `\dontrun{}` (`get_data_from_map` and `hc_mapNavigation`) to fix CRAN Package Check 403 errors.
+* Renamed internal helper function `hchart.pca` to `hchart_pca` to resolve an unregistered S3 method mismatch NOTE.
+
 # highcharter 0.9.4
 
 ## Changes

--- a/R/hchart.R
+++ b/R/hchart.R
@@ -442,7 +442,7 @@ hchart.dist <- function(object, ...) {
 #' V(net)$betweenness <- round(betweenness(net), 2)
 #' V(net)$degree <- degree(net)
 #' V(net)$size <- V(net)$degree
-#' V(net)$comm <- membership(wc)
+#' V(net)$comm <- as.vector(membership(wc))
 #' V(net)$color <- colorize(membership(wc))
 #' hchart(net, layout = layout_with_fr)
 #' 

--- a/R/hchart.R
+++ b/R/hchart.R
@@ -754,7 +754,7 @@ hchart.density <- function(object, type = "area", ...) {
 }
 
 #' @importFrom dplyr as_tibble
-hchart.pca <- function(sdev, n.obs, scores, loadings, ...,
+hchart_pca <- function(sdev, n.obs, scores, loadings, ...,
                        choices = 1L:2L, scale = 1) {
   stopifnot(length(choices) == 2L)
   stopifnot(0 <= scale | scale <= 1)
@@ -804,7 +804,7 @@ hchart.pca <- function(sdev, n.obs, scores, loadings, ...,
 
 #' @export
 hchart.princomp <- function(object, ..., choices = 1L:2L, scale = 1) {
-  hchart.pca(object$sdev, object$n.obs, object$scores, object$loadings,
+  hchart_pca(object$sdev, object$n.obs, object$scores, object$loadings,
     choices = choices, scale = scale, ...
   )
 }
@@ -812,7 +812,7 @@ hchart.princomp <- function(object, ..., choices = 1L:2L, scale = 1) {
 #' @importFrom dplyr as_tibble
 #' @export
 hchart.prcomp <- function(object, ..., choices = 1L:2L, scale = 1) {
-  hchart.pca(object$sdev, nrow(object$x), object$x, object$rotation,
+  hchart_pca(object$sdev, nrow(object$x), object$x, object$rotation,
     choices = choices, scale = scale, ...
   )
 }

--- a/R/hchart.R
+++ b/R/hchart.R
@@ -438,7 +438,7 @@ hchart.dist <- function(object, ...) {
 #' wc <- cluster_walktrap(net)
 #' V(net)$label <- seq(N)
 #' V(net)$name <- paste("I'm #", seq(N))
-#' V(net)$page_rank <- round(page.rank(net)$vector, 2)
+#' V(net)$page_rank <- round(page_rank(net)$vector, 2)
 #' V(net)$betweenness <- round(betweenness(net), 2)
 #' V(net)$degree <- degree(net)
 #' V(net)$size <- V(net)$degree

--- a/R/highmaps.R
+++ b/R/highmaps.R
@@ -201,8 +201,10 @@ download_map_data <- function(url = "custom/world.js", showinfo = FALSE,
 #' The urls are listed in \url{https://code.highcharts.com/mapdata/}.
 #' @param mapdata A list obtained from \code{\link{download_map_data}}.
 #' @examples
+#' \dontrun{
 #' dta <- download_map_data("https://code.highcharts.com/mapdata/countries/us/us-ca-all.js")
 #' get_data_from_map(dta)
+#' }
 #' @seealso \code{\link{download_map_data}}
 #' @importFrom purrr map_lgl
 #' @export

--- a/R/highmaps.R
+++ b/R/highmaps.R
@@ -162,6 +162,8 @@ hcmap <- function(map = "custom/world",
 #' @param showinfo Show the properties of the downloaded map to know how
 #'   are the keys to add data in \code{hcmap}.
 #' @param quiet Boolean parameter to turn off download messages (on by default).
+#' @param method A string value for the download method used by
+#'   \code{\link[utils]{download.file}}.
 #' @examples
 #' \dontrun{
 #' mpdta <- download_map_data("https://code.highcharts.com/mapdata/countries/us/us-ca-all.js")
@@ -176,14 +178,14 @@ hcmap <- function(map = "custom/world",
 #' @importFrom stringr str_remove
 #' @export
 download_map_data <- function(url = "custom/world.js", showinfo = FALSE,
-                              quiet = FALSE) {
+                              quiet = FALSE, method = "curl") {
   url <- sprintf(
     "https://code.highcharts.com/mapdata/%s",
     fix_map_name(url)
   )
 
   tmpfile <- tempfile(fileext = ".js")
-  download.file(url, tmpfile, quiet = quiet)
+  download.file(url, tmpfile, quiet = quiet, method = method)
   mapdata <- readLines(tmpfile, warn = FALSE, encoding = "UTF-8")
   mapdata[1] <- gsub(".* = ", "", mapdata[1])
   mapdata <- paste(mapdata, collapse = "\n")

--- a/dev/sandbox/hchart.R
+++ b/dev/sandbox/hchart.R
@@ -94,7 +94,7 @@ V(net)$page_rank <- round(page_rank(net)$vector, 2)
 V(net)$betweenness <- round(betweenness(net), 2)
 V(net)$degree <- degree(net)
 V(net)$size <- V(net)$degree
-V(net)$comm <- membership(wc)
+V(net)$comm <- as.vector(membership(wc))
 V(net)$color <- colorize(membership(wc))
 
 hchart(net, layout = layout_with_fr)

--- a/dev/sandbox/hchart.R
+++ b/dev/sandbox/hchart.R
@@ -90,7 +90,7 @@ wc <- cluster_walktrap(net)
 
 V(net)$label <- 1:40
 V(net)$name <- 1:40
-V(net)$page_rank <- round(page.rank(net)$vector, 2)
+V(net)$page_rank <- round(page_rank(net)$vector, 2)
 V(net)$betweenness <- round(betweenness(net), 2)
 V(net)$degree <- degree(net)
 V(net)$size <- V(net)$degree

--- a/dev/sandbox/igraph.R
+++ b/dev/sandbox/igraph.R
@@ -72,7 +72,7 @@ V(net)$label <- V(net)$name %>%
   map_chr(function(x) {
     x %>% unlist() %>% str_c(collapse = "")
   })
-V(net)$size <- degree(net)  # page.rank(net)$vector
+V(net)$size <- degree(net)  # page_rank(net)$vector
 
 cl <- cluster_resolution(net)
 

--- a/dev/sandbox/igraph2.R
+++ b/dev/sandbox/igraph2.R
@@ -38,8 +38,8 @@ wc <- cluster_walktrap(g)
 nc <- length(unique(membership(wc)))
 
 V(g)$label <- V(g)$name
-V(g)$page_rank <- round(page.rank(g)$vector, 2)
-V(g)$page_rank <- round(page.rank(g)$vector, 2)
+V(g)$page_rank <- round(page_rank(g)$vector, 2)
+V(g)$page_rank <- round(page_rank(g)$vector, 2)
 V(g)$betweenness <- round(betweenness(g), 2)
 V(g)$degree <- degree(g)
 V(g)$size <- V(g)$degree

--- a/dev/sandbox/igraph2.R
+++ b/dev/sandbox/igraph2.R
@@ -35,7 +35,7 @@ g <- graph.data.frame(relationships, directed = FALSE, vertices = v)
 
 wc <- cluster_walktrap(g)
 
-nc <- length(unique(membership(wc)))
+nc <- length(unique(as.vector(membership(wc))))
 
 V(g)$label <- V(g)$name
 V(g)$page_rank <- round(page_rank(g)$vector, 2)
@@ -43,7 +43,7 @@ V(g)$page_rank <- round(page_rank(g)$vector, 2)
 V(g)$betweenness <- round(betweenness(g), 2)
 V(g)$degree <- degree(g)
 V(g)$size <- V(g)$degree
-V(g)$comm <- membership(wc)
+V(g)$comm <- as.vector(membership(wc))
 V(g)$color <- colorize(membership(wc))
 
 #+

--- a/man/download_map_data.Rd
+++ b/man/download_map_data.Rd
@@ -4,7 +4,12 @@
 \alias{download_map_data}
 \title{Helper function to download the map data form a url}
 \usage{
-download_map_data(url = "custom/world.js", showinfo = FALSE, quiet = FALSE)
+download_map_data(
+  url = "custom/world.js",
+  showinfo = FALSE,
+  quiet = FALSE,
+  method = "curl"
+)
 }
 \arguments{
 \item{url}{The map's url.}
@@ -13,6 +18,9 @@ download_map_data(url = "custom/world.js", showinfo = FALSE, quiet = FALSE)
 are the keys to add data in \code{hcmap}.}
 
 \item{quiet}{Boolean parameter to turn off download messages (on by default).}
+
+\item{method}{A string value for the download method used by
+\code{\link[utils]{download.file}}.}
 }
 \description{
 The urls are listed in \url{https://code.highcharts.com/mapdata/}.

--- a/man/get_data_from_map.Rd
+++ b/man/get_data_from_map.Rd
@@ -15,8 +15,10 @@ Helper function to get the data inside the map data
 The urls are listed in \url{https://code.highcharts.com/mapdata/}.
 }
 \examples{
+\dontrun{
 dta <- download_map_data("https://code.highcharts.com/mapdata/countries/us/us-ca-all.js")
 get_data_from_map(dta)
+}
 }
 \seealso{
 \code{\link{download_map_data}}

--- a/man/hchart.igraph.Rd
+++ b/man/hchart.igraph.Rd
@@ -30,7 +30,7 @@ V(net)$page_rank <- round(page_rank(net)$vector, 2)
 V(net)$betweenness <- round(betweenness(net), 2)
 V(net)$degree <- degree(net)
 V(net)$size <- V(net)$degree
-V(net)$comm <- membership(wc)
+V(net)$comm <- as.vector(membership(wc))
 V(net)$color <- colorize(membership(wc))
 hchart(net, layout = layout_with_fr)
 

--- a/man/hchart.igraph.Rd
+++ b/man/hchart.igraph.Rd
@@ -26,7 +26,7 @@ net <- sample_gnp(N, p = 2 / N)
 wc <- cluster_walktrap(net)
 V(net)$label <- seq(N)
 V(net)$name <- paste("I'm #", seq(N))
-V(net)$page_rank <- round(page.rank(net)$vector, 2)
+V(net)$page_rank <- round(page_rank(net)$vector, 2)
 V(net)$betweenness <- round(betweenness(net), 2)
 V(net)$degree <- degree(net)
 V(net)$size <- V(net)$degree

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -47,7 +47,6 @@ reference:
   - hc_credits
   - hc_drilldown
   - hc_exporting
-  - hc_labels
   - hc_legend
   - hc_loading
   - hc_pane

--- a/pkgdown/_pkgdown.yml
+++ b/pkgdown/_pkgdown.yml
@@ -47,6 +47,7 @@ reference:
   - hc_credits
   - hc_drilldown
   - hc_exporting
+  - hc_labels
   - hc_legend
   - hc_loading
   - hc_pane

--- a/pkgdown/index-examples.R
+++ b/pkgdown/index-examples.R
@@ -100,7 +100,7 @@ net <- sample_pa(N)
 wc <- cluster_walktrap(net)
 V(net)$label <- 1:N
 V(net)$name <- 1:N
-V(net)$page_rank <- round(page.rank(net)$vector, 2)
+V(net)$page_rank <- round(page_rank(net)$vector, 2)
 V(net)$betweenness <- round(betweenness(net), 2)
 V(net)$degree <- degree(net)
 V(net)$size <- V(net)$degree + 1

--- a/pkgdown/index-examples.R
+++ b/pkgdown/index-examples.R
@@ -104,7 +104,7 @@ V(net)$page_rank <- round(page_rank(net)$vector, 2)
 V(net)$betweenness <- round(betweenness(net), 2)
 V(net)$degree <- degree(net)
 V(net)$size <- V(net)$degree + 1
-V(net)$comm <- membership(wc)
+V(net)$comm <- as.vector(membership(wc))
 V(net)$color <- colorize(membership(wc), viridisLite::magma(length(wc)))
 p5 <- hchart(net, layout = layout_with_fr, maxSize = 13)
 

--- a/pkgdown/index.Rmd
+++ b/pkgdown/index.Rmd
@@ -122,7 +122,7 @@ V(net)$page_rank <- round(page_rank(net)$vector, 2)
 V(net)$betweenness <- round(betweenness(net), 2)
 V(net)$degree <- degree(net)
 V(net)$size <- V(net)$degree + 1
-V(net)$comm <- membership(wc)
+V(net)$comm <- as.vector(membership(wc))
 V(net)$color <- colorize(membership(wc), viridisLite::magma(length(wc)))
 p5 <- hchart(net, layout = layout_with_fr, maxSize = 13)
   

--- a/pkgdown/index.Rmd
+++ b/pkgdown/index.Rmd
@@ -118,7 +118,7 @@ net <- sample_pa(N)
 wc <- cluster_walktrap(net)
 V(net)$label <- 1:N
 V(net)$name <- 1:N
-V(net)$page_rank <- round(page.rank(net)$vector, 2)
+V(net)$page_rank <- round(page_rank(net)$vector, 2)
 V(net)$betweenness <- round(betweenness(net), 2)
 V(net)$degree <- degree(net)
 V(net)$size <- V(net)$degree + 1

--- a/tests/testthat/test-hchart.R
+++ b/tests/testthat/test-hchart.R
@@ -54,7 +54,7 @@ test_that("hchart returns a valid graph after valid data input", {
   V(net)$betweenness <- round(betweenness(net), 2)
   V(net)$degree <- degree(net)
   V(net)$size <- V(net)$degree
-  V(net)$comm <- membership(wc)
+  V(net)$comm <- as.vector(membership(wc))
   V(net)$color <- colorize(membership(wc))
 
   h <- hchart(net, layout = layout_with_fr)

--- a/tests/testthat/test-hchart.R
+++ b/tests/testthat/test-hchart.R
@@ -50,7 +50,7 @@ test_that("hchart returns a valid graph after valid data input", {
 
   V(net)$label <- seq(N)
   V(net)$name <- paste("I'm #", seq(N))
-  V(net)$page_rank <- round(page.rank(net)$vector, 2)
+  V(net)$page_rank <- round(page_rank(net)$vector, 2)
   V(net)$betweenness <- round(betweenness(net), 2)
   V(net)$degree <- degree(net)
   V(net)$size <- V(net)$degree

--- a/vignettes/hchart.Rmd
+++ b/vignettes/hchart.Rmd
@@ -125,7 +125,7 @@ V(net)$page_rank <- round(page_rank(net)$vector, 2)
 V(net)$betweenness <- round(betweenness(net), 2)
 V(net)$degree <- degree(net)
 V(net)$size <- V(net)$degree
-V(net)$comm <- membership(wc)
+V(net)$comm <- as.vector(membership(wc))
 V(net)$color <- colorize(membership(wc))
 
 hchart(net, layout = layout_with_fr)

--- a/vignettes/hchart.Rmd
+++ b/vignettes/hchart.Rmd
@@ -121,7 +121,7 @@ wc <- cluster_walktrap(net)
 
 V(net)$label <- seq(N)
 V(net)$name <- paste("I'm #", seq(N))
-V(net)$page_rank <- round(page.rank(net)$vector, 2)
+V(net)$page_rank <- round(page_rank(net)$vector, 2)
 V(net)$betweenness <- round(betweenness(net), 2)
 V(net)$degree <- degree(net)
 V(net)$size <- V(net)$degree


### PR DESCRIPTION
* Wrapped examples making network calls in `\dontrun{}` (`get_data_from_map` and `hc_mapNavigation`) to fix CRAN Package Check 403 errors.
* Renamed internal helper function `hchart.pca` to `hchart_pca` to resolve an unregistered S3 method mismatch NOTE.

Resolves #842 
